### PR TITLE
PML changes

### DIFF
--- a/examples/ecf.cpp
+++ b/examples/ecf.cpp
@@ -177,7 +177,8 @@ void RunSimulation(const STATE lambda, const int nEigenpairs, const int pOrder, 
 
   
   wgma::cmeshtools::SetupGmshMaterialData(gmshmats, matmap, bcmap,
-                                          alphaPML, volMatIdVec,
+                                          alphaPML, alphaPML,
+                                          volMatIdVec,
                                           erVec, urVec,
                                           pmlDataVec, bcDataVec);
   /*

--- a/examples/ribwg.cpp
+++ b/examples/ribwg.cpp
@@ -159,7 +159,8 @@ int main(int argc, char *argv[]) {
 
   
   wgma::cmeshtools::SetupGmshMaterialData(gmshmats, matmap, bcmap,
-                                          alphaPML, volMatIdVec,
+                                          alphaPML, alphaPML,
+                                          volMatIdVec,
                                           erVec, urVec,
                                           pmlDataVec, bcDataVec);
   /*

--- a/examples/stepfiber.cpp
+++ b/examples/stepfiber.cpp
@@ -210,7 +210,8 @@ int main(int argc, char *argv[]) {
     int pmlCount{0};
     for(auto &pml : pmlDataVec){
       pml.id = matIdVec[matCount++];
-      pml.alpha = alphaPML;
+      pml.alphax = alphaPML;
+      pml.alphay = alphaPML;
       pml.t = pmlTypeVec[pmlCount++];
     }
 

--- a/wgma/CMakeLists.txt
+++ b/wgma/CMakeLists.txt
@@ -11,6 +11,7 @@ set(headers
   include/pmltypes.hpp
   include/gmeshtools.hpp
   include/cmeshtools.hpp
+  include/cmeshtools_impl.hpp
   include/wganalysis.hpp
   include/slepcepshandler.hpp
   )

--- a/wgma/include/cmeshtools.hpp
+++ b/wgma/include/cmeshtools.hpp
@@ -35,7 +35,8 @@ namespace wgma::cmeshtools{
    @param [in] gmshmats vector returned from ReadGmshMesh
    @param [in] matmap for a given region name, contains the pairs (er,ur) for non pml regions
    @param [in] bcmap for a given boundary name, contains the bc type
-   @param [in] alphaPML PML attenuation constant
+   @param [in] alphaPMLx PML attenuation constant in the x direction
+   @param [in] alphaPMLy PML attenuation constant in the y direction
    @param [out] volmatids material identifiers of non-pml regions
    @param [out] ervec electric permittivity of non-pml regions
    @param [out] urvec magnetic permeability of non-pml regions
@@ -47,7 +48,8 @@ namespace wgma::cmeshtools{
 void SetupGmshMaterialData(const TPZVec<std::map<std::string,int>> &gmshmats,
                        const std::map<std::string,std::pair<CSTATE,CSTATE>> &matmap,
                        const std::map<std::string,wgma::bc::type> &bcmap,
-                       const STATE alphaPML,
+                       const STATE alphaPMLx,
+                       const STATE alphaPMLy,
                        TPZVec<int> &volmatids,
                        TPZVec<CSTATE> &ervec,
                        TPZVec<CSTATE> &urvec,
@@ -81,7 +83,8 @@ void SetupGmshMaterialData(const TPZVec<std::map<std::string,int>> &gmshmats,
      All the other mesh regions (excluding BCs) should have been previously inserted,
      so the function can identify to which region the PML is associated.
      @param[in] matId pml material identifier.
-     @param[in] alpha attenuation constant.
+     @param[in] alphax attenuation constant in the x-direction.
+     @param[in] alphay attenuation constant in the y-direction.
      @param[in] type pml type.
      @param[in] volmats identifiers of valid mesh regions for pml neighbours
      @param[in] gmesh the geometric mesh.
@@ -89,7 +92,8 @@ void SetupGmshMaterialData(const TPZVec<std::map<std::string,int>> &gmshmats,
      @return This method calls FindPMLNeighbourMaterial internally.
   */
   void
-  AddRectangularPMLRegion(const int matId, const int alpha,
+  AddRectangularPMLRegion(const int matId,
+                          const int alphax,const int alphay,
                           const wgma::pml::type type,
                           const std::set<int> &volmats,
                           TPZAutoPointer<TPZGeoMesh> gmesh,

--- a/wgma/include/cmeshtools.hpp
+++ b/wgma/include/cmeshtools.hpp
@@ -82,6 +82,8 @@ void SetupGmshMaterialData(const TPZVec<std::map<std::string,int>> &gmshmats,
      @brief Adds a rectangular PML region to a computational mesh.
      All the other mesh regions (excluding BCs) should have been previously inserted,
      so the function can identify to which region the PML is associated.
+     @tparam MATPML material to create in the PML
+     @tparam MATVOL material from which the PML inherits
      @param[in] matId pml material identifier.
      @param[in] alphax attenuation constant in the x-direction.
      @param[in] alphay attenuation constant in the y-direction.
@@ -91,6 +93,7 @@ void SetupGmshMaterialData(const TPZVec<std::map<std::string,int>> &gmshmats,
      @param[in] cmesh the computational mesh.
      @return This method calls FindPMLNeighbourMaterial internally.
   */
+  template<class MATPML, class MATVOL>
   void
   AddRectangularPMLRegion(const int matId,
                           const int alphax,const int alphay,

--- a/wgma/include/pmltypes.hpp
+++ b/wgma/include/pmltypes.hpp
@@ -65,11 +65,13 @@ namespace wgma{
 
     //! Data structure for easier creation of PML regions
     struct data{
-      type t;
-      STATE alpha;
-      int id;
-      explicit data(int i, type tp, STATE a) : id(i), t(tp), alpha(a) {}
-      data() : id(-100), alpha(0), t(type::xm) {}
+      type t{type::xm};
+      STATE alphax{0};
+      STATE alphay{0};
+      int id{-100};
+      explicit data(int i, type tp, STATE ax, STATE ay) :
+        id(i), t(tp), alphax(ax), alphay(ay) {}
+      data() = default;
     };
   };
   

--- a/wgma/src/cmeshtools.cpp
+++ b/wgma/src/cmeshtools.cpp
@@ -20,7 +20,8 @@ cmeshtools::SetupGmshMaterialData(
   const TPZVec<std::map<std::string,int>> &gmshmats,
   const std::map<std::string,std::pair<CSTATE,CSTATE>> &matmap,
   const std::map<std::string,wgma::bc::type> &bcmap,
-  const STATE alphaPML,
+  const STATE alphaPMLx,
+  const STATE alphaPMLy,
   TPZVec<int> &volmatids,
   TPZVec<CSTATE> &ervec,
   TPZVec<CSTATE> &urvec,
@@ -60,7 +61,8 @@ cmeshtools::SetupGmshMaterialData(
         if(test){
           pmlvec.Resize(pos+1);
           pmlvec[pos].id = id;
-          pmlvec[pos].alpha = alphaPML;
+          pmlvec[pos].alphax = alphaPMLx;
+          pmlvec[pos].alphay = alphaPMLy;
           pmlvec[pos].t = pmltypes[ipml];
           found = true;
           break;
@@ -205,9 +207,10 @@ cmeshtools::CreateCMesh(
   }
   for(auto pml : pmlDataVec){
     const auto id = pml.id;
-    const auto alpha = pml.alpha;
+    const auto alphax = pml.alphax;
+    const auto alphay = pml.alphay;
     const auto type = pml.t;
-    AddRectangularPMLRegion(id, alpha, type, volmats, gmesh, cmeshMF);
+    AddRectangularPMLRegion(id, alphax, alphay, type, volmats, gmesh, cmeshMF);
   }
   
   TPZBndCond *bcMat = nullptr;
@@ -280,7 +283,8 @@ cmeshtools::FindPMLNeighbourMaterial(
 }
 
 void
-cmeshtools::AddRectangularPMLRegion(const int matId, const int alpha,
+cmeshtools::AddRectangularPMLRegion(const int matId,
+                                    const int alphax, const int alphay,
                                     const wgma::pml::type type,
                                     const std::set<int> &volmats,
                                     TPZAutoPointer<TPZGeoMesh> gmesh,
@@ -352,8 +356,8 @@ cmeshtools::AddRectangularPMLRegion(const int matId, const int alpha,
   }
   
   auto pmlMat = new TPZWaveguideModalAnalysisPML(matId, *neighMat);
-  if(attx) pmlMat->SetAttX(xBegin, alpha, dX);
-  if(atty) pmlMat->SetAttY(yBegin, alpha, dY);
+  if(attx) pmlMat->SetAttX(xBegin, alphax, dX);
+  if(atty) pmlMat->SetAttY(yBegin, alphay, dY);
   cmesh->InsertMaterialObject(pmlMat);
   
 }

--- a/wgma/src/cmeshtools.cpp
+++ b/wgma/src/cmeshtools.cpp
@@ -1,5 +1,6 @@
 #include "cmeshtools.hpp"
 #include "pmltypes.hpp"
+#include "cmeshtools_impl.hpp"
 
 #include <pzgmesh.h>
 #include <pzcmesh.h>
@@ -210,7 +211,9 @@ cmeshtools::CreateCMesh(
     const auto alphax = pml.alphax;
     const auto alphay = pml.alphay;
     const auto type = pml.t;
-    AddRectangularPMLRegion(id, alphax, alphay, type, volmats, gmesh, cmeshMF);
+    AddRectangularPMLRegion<
+      TPZWaveguideModalAnalysisPML,TPZWaveguideModalAnalysis
+      >(id, alphax, alphay, type, volmats, gmesh, cmeshMF);
   }
   
   TPZBndCond *bcMat = nullptr;
@@ -280,86 +283,6 @@ cmeshtools::FindPMLNeighbourMaterial(
     DebugStop();
   }
   return closestEl->MaterialId();
-}
-
-void
-cmeshtools::AddRectangularPMLRegion(const int matId,
-                                    const int alphax, const int alphay,
-                                    const wgma::pml::type type,
-                                    const std::set<int> &volmats,
-                                    TPZAutoPointer<TPZGeoMesh> gmesh,
-                                    TPZAutoPointer<TPZCompMesh> cmesh)
-{
-
-  //let us find the (xmin,xmax) and (ymin,ymax) of the PML region
-  REAL xMax = -1e20, xMin = 1e20, yMax = -1e20, yMin = 1e20;
-  for (auto geo : gmesh->ElementVec()){
-    if (geo && geo->MaterialId() == matId) {
-      for (int iNode = 0; iNode < geo->NCornerNodes(); ++iNode) {
-        TPZManVector<REAL, 3> co(3);
-        geo->Node(iNode).GetCoordinates(co);
-        const REAL &xP = co[0];
-        const REAL &yP = co[1];
-        if (xP > xMax) {
-          xMax = xP;
-        }
-        if (xP < xMin) {
-          xMin = xP;
-        }
-        if (yP > yMax) {
-          yMax = yP;
-        }
-        if (yP < yMin) {
-          yMin = yP;
-        }
-      }
-    }
-  }
-
-
-  //now we compute xBegin, yBegin, attx, atty and d for the material ctor
-  const bool attx = wgma::pml::attx(type);
-  const bool atty = wgma::pml::atty(type);
-  
-  REAL xBegin{-1}, yBegin{-1}, dX{-01101991.}, dY{-01101991.};
-  REAL boundPosX{-01101991.}, boundPosY{-01101991.};
-  if(attx){
-    const int xdir = wgma::pml::xinfo(type);
-    dX = xMax - xMin;
-    xBegin = xdir > 0 ? xMin : xMax;
-    boundPosX = xBegin;
-    boundPosY = (yMax + yMin)/2;
-  }
-
-  if(atty){
-    const int ydir = wgma::pml::yinfo(type);
-    dY = yMax - yMin;
-    yBegin = ydir > 0 ? yMin : yMax;
-    boundPosX = (xMax + xMin)/2;
-    boundPosY = yBegin;
-  }
-
-  if(attx && atty){
-    boundPosX = xBegin;
-    boundPosY = yBegin;
-  }
-  //find the neighbouring material
-  const auto neighMatId =
-    FindPMLNeighbourMaterial(gmesh, matId, volmats, boundPosX, boundPosY);
-
-  auto neighMat = dynamic_cast<TPZWaveguideModalAnalysis*>(
-    cmesh->FindMaterial(neighMatId));
-  if(!neighMat){
-    PZError<<__PRETTY_FUNCTION__;
-    PZError<<"\n neighbouring material not found in mesh, aborting...."<<std::endl;
-    DebugStop();
-  }
-  
-  auto pmlMat = new TPZWaveguideModalAnalysisPML(matId, *neighMat);
-  if(attx) pmlMat->SetAttX(xBegin, alphax, dX);
-  if(atty) pmlMat->SetAttY(yBegin, alphay, dY);
-  cmesh->InsertMaterialObject(pmlMat);
-  
 }
 
 void


### PR DESCRIPTION
- Possibility of different attenuation constant on x and y directions
- `AddRectangularPMLRegion` is now a template method. It could be used for adding PML regions for other problems, *i.e.*, problems that do not rely on `TPZWaveguideModalAnalysis` and `TPZWaveguideModalAnalysisPML` materials. For this usage, one needs to include `#include <cmeshtools_impl.hpp>`