### PR TITLE
Inheritance change

### DIFF
--- a/wgma/include/scattering.hpp
+++ b/wgma/include/scattering.hpp
@@ -15,7 +15,7 @@ namespace wgma::scattering{
   /**
      @brief  Class responsible for managing the scattering analysis of planar waveguides
   */
-  class Analysis{
+  class Analysis : private TPZLinearAnalysis {
   public:
     /**
        @brief Creates the analysis module based on a given computational mesh
@@ -29,18 +29,20 @@ namespace wgma::scattering{
                        const int n_threads, const bool reorder_eqs=true,
                        const bool filter_bound=true);
     //! Sets a custom linear solver to be copied to underlying TPZAnalysis(advanced)
-    void SetSolver(const TPZMatrixSolver<CSTATE> &solv);
+    using TPZLinearAnalysis::SetSolver;
     /**
        @brief Gets a copy of the linear solver for easier configuration (advanced)
        @note A call to Analysis::SetSolver must be made afterwards.
     */
-    TPZMatrixSolver<CSTATE> & GetSolver() const;
+    TPZMatrixSolver<CSTATE> & GetSolver(){
+      return TPZLinearAnalysis::MatrixSolver<CSTATE>();
+    }
     /**
        @brief Assembles the algebraic system
      */
     void Assemble();
     /**
-       @brief Assembles the rhs of hte algebraic system
+       @brief Assembles the rhs of the algebraic system
        @param[in] identifiers of the materials to be assembled (source materials)
      */
     void AssembleRhs(std::set<int> matids);
@@ -57,8 +59,6 @@ namespace wgma::scattering{
   protected:
     //! H1 mesh
     TPZAutoPointer<TPZCompMesh> m_cmesh{nullptr};
-    //! Analysis instance
-    TPZAutoPointer<TPZLinearAnalysis> m_an{nullptr};
     //! Whether the matrices have been assembled already
     bool m_assembled{false};
     //! Number of H1 dofs

--- a/wgma/include/wganalysis.hpp
+++ b/wgma/include/wganalysis.hpp
@@ -66,10 +66,14 @@ namespace wgma::wganalysis{
       @brief Gets calculated eigenvalues
      */
     using TPZEigenAnalysis::GetEigenvalues;
+    //! Sets eigenvalues
+    using TPZEigenAnalysis::SetEigenvalues;
     /*
       @brief Gets calculated eigenvectors
      */
     using TPZEigenAnalysis::GetEigenvectors;
+    //! Sets eigenvectors
+    using TPZEigenAnalysis::SetEigenvectors;
 
     /**
        @brief Export eigenvalues to in a csv format and append it to a file.

--- a/wgma/include/wganalysis.hpp
+++ b/wgma/include/wganalysis.hpp
@@ -59,9 +59,12 @@ namespace wgma::wganalysis{
       @brief Loads the isol-th solution (eigenvector) in the computational mesh.
       This method is specially useful if the solution from the modal analysis
       will be used in another FEM scheme (as a source, for instance).
-      @note Derived classes should call base class function first.
+      @note Derived classes will implement LoadSolutionInternal.
      */
-    virtual void LoadSolution(const int isol) = 0;
+    void LoadSolution(const int isol);
+
+    //! Loads all computed eigenvectors into the mesh
+    void LoadAllSolutions();
     /*
       @brief Gets calculated eigenvalues
      */
@@ -91,8 +94,10 @@ namespace wgma::wganalysis{
      */
     virtual void WriteToCsv(std::string filename, STATE lambda) = 0;
   protected:
+
+    virtual void LoadSolutionInternal(const int isol, const int nsol) = 0;
+    using TPZEigenAnalysis::LoadSolution;
     using TPZAnalysis::SetCompMeshInit;
-    using TPZAnalysis::LoadSolution;
     using TPZAnalysis::SetStructuralMatrix;
     using TPZAnalysis::StructMatrix;
     //! Perform necessary adjustments on the eigensolver
@@ -123,14 +128,6 @@ namespace wgma::wganalysis{
                const int n_threads, const bool reorder_eqs=true,
                const bool filter_bound=true);
 
-    /*
-      @brief Loads the isol-th solution (eigenvector) in the computational mesh.
-      This method is specially useful if the solution from the modal analysis
-      will be used in another FEM scheme (as a source, for instance).
-      @note Derived classes should call base class function first.
-     */
-    void LoadSolution(const int isol) override;
-
     /**
        @brief Export eigenvalues to in a csv format and append it to a file.
        The following values are exported:
@@ -150,7 +147,8 @@ namespace wgma::wganalysis{
     /** @brief Counts active equations per approximation space for the 2D waveguide modal analysis.*/
     void CountActiveEqs(int &neq, int&nh1, int &nhcurl);
   private:
-    using Wgma::LoadSolution;
+    void LoadSolutionInternal(const int isol, const int ncols) override;
+    
     void AdjustSolver(TPZEigenSolver<CSTATE> *solv) override;
     //! Combined computational mesh (hcurl and h1)
     TPZAutoPointer<TPZCompMesh> m_cmesh_mf{nullptr};
@@ -183,15 +181,6 @@ namespace wgma::wganalysis{
     WgmaPlanar(TPZAutoPointer<TPZCompMesh> cmesh,
                const int n_threads, const bool reorder_eqs=true,
                const bool filter_bound=true);
-
-    /*
-      @brief Loads the isol-th solution (eigenvector) in the computational mesh.
-      This method is specially useful if the solution from the modal analysis
-      will be used in another FEM scheme (as a source, for instance).
-      @note Derived classes should call base class function first.
-     */
-    void LoadSolution(const int isol) override;
-
     /**
        @brief Export eigenvalues to in a csv format and append it to a file.
        The following values are exported:
@@ -211,7 +200,7 @@ namespace wgma::wganalysis{
     /** @brief Counts active equations per approximation space for the 2D waveguide modal analysis.*/
     void CountActiveEqs(int &neq);
   protected:
-    using Wgma::LoadSolution;
+    void LoadSolutionInternal(const int isol, const int nsol) override;
     //! Computational mesh
     TPZAutoPointer<TPZCompMesh> m_cmesh{nullptr};
     //! Total number of dofs

--- a/wgma/src/wganalysis.cpp
+++ b/wgma/src/wganalysis.cpp
@@ -96,7 +96,17 @@ namespace wgma::wganalysis{
                <<"were calculated. Aborting...\n";
       DebugStop();
     }
+
+    LoadSolutionInternal(isol, 1);
   }
+
+
+  void Wgma::LoadAllSolutions()
+  {
+    const auto nsol = this->GetEigenvectors().Cols();
+    LoadSolutionInternal(0, nsol);
+  }
+  
 
   Wgma2D::Wgma2D(const TPZVec<TPZAutoPointer<TPZCompMesh>> &meshvec,
                  const int n_threads, const bool reorder_eqs,
@@ -191,18 +201,14 @@ namespace wgma::wganalysis{
     std::cout << "------\t----------\t-------" << std::endl;
     return;
   }
-
-
-  void Wgma2D::LoadSolution(const int isol)
-  {
-    Wgma::LoadSolution(isol);
-    
-    
+  
+  void Wgma2D::LoadSolutionInternal(const int isol, const int ncols)
+  { 
     const auto &ev = this->GetEigenvalues();
     const auto &eigenvectors = this->GetEigenvectors();
 
     const auto neqOriginal = eigenvectors.Rows();
-    TPZFMatrix<CSTATE> evector(neqOriginal, 1, 0.);
+    TPZFMatrix<CSTATE> evector(neqOriginal, ncols, 0.);
     
     TPZManVector<TPZAutoPointer<TPZCompMesh>,2> meshVecPost(2);
     meshVecPost[0] = m_cmesh_h1;
@@ -217,8 +223,10 @@ namespace wgma::wganalysis{
         {tmp = tmp.real();}
       return tmp;
     }();
+
     
-    eigenvectors.GetSub(0, isol, neqOriginal, 1, evector);
+
+    eigenvectors.GetSub(0, isol, neqOriginal, ncols, evector);
     for(auto mat : m_cmesh_mf->MaterialVec()){
       auto id = mat.first;
       auto matPtr =
@@ -316,17 +324,18 @@ namespace wgma::wganalysis{
       neq = m_cmesh->NEquations();
     }
   }
-  void WgmaPlanar::LoadSolution(const int isol)
+
+  
+  void WgmaPlanar::LoadSolutionInternal(const int isol, const int nsol)
   {
-    Wgma::LoadSolution(isol);
 
     const auto &ev = this->GetEigenvalues();
     const auto &eigenvectors = this->GetEigenvectors();
     
     const auto neqOriginal = eigenvectors.Rows();
-    TPZFMatrix<CSTATE> evector(neqOriginal, 1, 0.);
+    TPZFMatrix<CSTATE> evector(neqOriginal, nsol, 0.);
 
-    eigenvectors.GetSub(0, isol, neqOriginal, 1, evector);
+    eigenvectors.GetSub(0, isol, neqOriginal, nsol, evector);
     this->LoadSolution(evector);
   }
 


### PR DESCRIPTION
Now the analysis classes derive privately from their NeoPZ counterparts, instead of having an instance of them.

The private inheritance aims to reduce the interface in order to avoid confusion.